### PR TITLE
Changing not_found_page to handle refresh on chats

### DIFF
--- a/terraform/cloud_storage.tf
+++ b/terraform/cloud_storage.tf
@@ -17,7 +17,7 @@ resource "google_storage_bucket" "frontend_bucket" {
   # Website configuration
   website {
     main_page_suffix = "index.html"
-    not_found_page   = "404.html"
+    not_found_page   = "index.html"
   }
 
   # CORS configuration for web access


### PR DESCRIPTION
This PR is changing not_found_page from 404.html to index.html to handle refreshes on chats.

NOTE: in developer tools network tab it still returns 404 for the chat id but the refresh is handled by the app router. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated error handling so unknown or deep-linked URLs load the main application instead of a 404 page, improving routing for single-page app navigation.
  * Enhances reliability of bookmarks and shared links to nested routes by serving the index page when paths are not directly recognized, reducing unexpected 404s for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->