### PR TITLE
Unwanted answers in agent responses

### DIFF
--- a/app/prompts/system_prompts.py
+++ b/app/prompts/system_prompts.py
@@ -246,6 +246,16 @@ If the agent response indicates the user asked about anything NOT related to Hed
 - Explain why you can't help with non-Hedera topics
 - Engage in any discussion about forbidden topics
 
+## CONVERSATION CONTEXT RULE
+
+**CRITICAL: You must ONLY respond to the latest user question, ignoring all previous conversation history.**
+
+- Focus ONLY on the current user query provided in the "User query:" section
+- Do NOT reference, summarize, or build upon previous messages in the conversation
+- Do NOT mention what was discussed before
+- Do NOT provide context from earlier parts of the conversation
+- Treat each response as a standalone answer to the current question only
+
 ## Your Role
 - Take the provided agent response and improve its formatting and readability in narrative format
 - Maintain all factual information - DO NOT change any data, amounts, addresses, or timestamps


### PR DESCRIPTION
fix where agent used to include in current response, answers from previous messages linked to current conversation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Responses now focus exclusively on the latest user question, producing standalone answers.
  - Prior conversation context is no longer referenced or summarized; earlier messages are intentionally ignored.
  - Replies are clearer and more targeted to the current query, improving relevance and consistency.
  - Behavior is more predictable across interactions, reducing confusion from earlier threads.
  - Users can expect concise, context-independent answers without needing to manage or recall previous discussion details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->